### PR TITLE
FIX: Broken icons because of rename

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -80,11 +80,11 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="/connectors/topic-list-before-reply-count/icon.raw">
-  {{d-icon 'comments-o'}}
+  {{d-icon 'far-comment'}}
 </script>
 
 <script type="text/x-handlebars" data-template-name="/connectors/topic-list-before-relative-date/icon.raw">
-  {{d-icon 'clock-o'}}
+  {{d-icon 'far-clock'}}
 </script>
 
 <script type="text/x-handlebars" data-template-name="list/visited-line.raw">

--- a/mobile/header.html
+++ b/mobile/header.html
@@ -38,7 +38,7 @@
           </span>
           <span class="age activity" title="{{topic.bumpedAtTitle}}">
             <a href="{{topic.lastPostUrl}}">
-              {{d-icon 'clock-o'}}
+              {{d-icon 'far-clock'}}
               {{format-date topic.bumpedAt format="tiny" noTitle="true"}}
             </a>
           </span>


### PR DESCRIPTION
Looks like a bunch of icons were renamed in discourse core:

https://github.com/discourse/discourse/blob/master/db/migrate/20200517140915_fa4_renames.json